### PR TITLE
[JAVAVSCODE-60] Added configuration for specifying user-defined vm arguments to start java language server

### DIFF
--- a/vscode/package.json
+++ b/vscode/package.json
@@ -163,6 +163,12 @@
 					"default": "",
 					"description": "VM options"
 				},
+				"jdk.serverVmOptions": {
+					"type": "array",
+					"default": [],
+					"description": "Specifies extra VM arguments used to launch the Java Language Server",
+					"scope": "machine-overridable"
+				},
 				"jdk.runConfig.env": {
 					"type": "string",
 					"default": "",

--- a/vscode/src/extension.ts
+++ b/vscode/src/extension.ts
@@ -807,6 +807,8 @@ function doActivateWithJDK(specifiedJDK: string | null, context: ExtensionContex
         if (isDarkColorTheme()) {
             extras.push('--laf', 'com.formdev.flatlaf.FlatDarkLaf');
         }
+        let serverVmOptions: string[] = workspace.getConfiguration('jdk').get("serverVmOptions",[]);
+        extras.push(...serverVmOptions.map(el => `-J${el}`));
         let p = launcher.launch(info, ...extras);
         handleLog(log, "LSP server launching: " + p.pid);
         handleLog(log, "LSP server user directory: " + userdir);


### PR DESCRIPTION
Added configuration `jdk.serverVmOptions` for specifying user-defined vm arguments to start the java language server.

For example: `"jdk.serverVmOptions": ["-Xmx2G","-Dnetbeans.logger.console=true","-ea"]` can be added in the settings.json file and above mentioned arguments would be used for launching the java language server.
