### PR TITLE
Issue with notebook configurations fixed

### DIFF
--- a/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookDocumentServiceHandlerImpl.java
+++ b/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookDocumentServiceHandlerImpl.java
@@ -142,8 +142,9 @@ public class NotebookDocumentServiceHandlerImpl implements NotebookDocumentServi
 
     @Override
     public void connect(LanguageClient client) {
-        NotebookConfigs.getInstance().initConfigs();
         LanguageClientInstance.getInstance().setClient((NbCodeLanguageClient) client);
+        NotebookConfigs.getInstance().initConfigs();
+
     }
 
     @Override


### PR DESCRIPTION
Refactorings done as a part of https://github.com/Achal1607/javavscode/commit/b02d6863f2d0067b2ce2804ff9c8e146fd6da7ed caused the issue. Language client must be set before initializing the configurations.