### PR TITLE
Fixed nb-telemetry isPreviewEnabled for gradle projects

### DIFF
--- a/nbcode/telemetry/src/org/netbeans/modules/nbcode/java/lsp/server/telemetry/SourceInfo.java
+++ b/nbcode/telemetry/src/org/netbeans/modules/nbcode/java/lsp/server/telemetry/SourceInfo.java
@@ -114,7 +114,7 @@ class SourceInfo {
     public boolean getPreviewEnabled(){
         try {
             return LspServerTelemetryManager.getInstance().isPreviewEnabled(file,
-                    owner == null ? LspServerTelemetryManager.ProjectType.standalone : LspServerTelemetryManager.getInstance().getProjectType(owner),
+                    owner,
                     getLanguageClient()).get();
         } catch (InterruptedException | ExecutionException ex) {
             LOG.log(Level.FINE, "exception while checking if preview enabled: {0}", (Object) ex);

--- a/patches/nb-telemetry.diff
+++ b/patches/nb-telemetry.diff
@@ -1,5 +1,5 @@
 diff --git a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspServerTelemetryManager.java b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspServerTelemetryManager.java
-index d82646afb1..7f4c88acd1 100644
+index d82646afb1..5018896480 100644
 --- a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspServerTelemetryManager.java
 +++ b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/LspServerTelemetryManager.java
 @@ -21,6 +21,7 @@ package org.netbeans.modules.java.lsp.server.protocol;
@@ -10,7 +10,7 @@ index d82646afb1..7f4c88acd1 100644
  import java.math.BigInteger;
  import java.nio.charset.StandardCharsets;
  import java.security.MessageDigest;
-@@ -28,25 +29,30 @@ import java.security.NoSuchAlgorithmException;
+@@ -28,25 +29,36 @@ import java.security.NoSuchAlgorithmException;
  import java.util.ArrayList;
  import java.util.Collection;
  import java.util.Collections;
@@ -18,8 +18,8 @@ index d82646afb1..7f4c88acd1 100644
 +import java.util.Iterator;
  import java.util.List;
  import java.util.Map;
--import java.util.Set;
 +import java.util.NavigableMap;
+ import java.util.Set;
 +import java.util.TreeMap;
  import java.util.WeakHashMap;
 +import java.util.concurrent.CompletableFuture;
@@ -33,19 +33,24 @@ index d82646afb1..7f4c88acd1 100644
  import org.eclipse.lsp4j.ConfigurationParams;
  import org.eclipse.lsp4j.MessageType;
  import org.eclipse.lsp4j.services.LanguageClient;
++import org.netbeans.api.annotations.common.NonNull;
 +import org.netbeans.api.java.platform.JavaPlatform;
++import org.netbeans.api.java.project.JavaProjectConstants;
  import org.netbeans.api.java.queries.CompilerOptionsQuery;
  import org.netbeans.api.java.queries.CompilerOptionsQuery.Result;
  import org.netbeans.api.project.Project;
  import org.netbeans.api.project.ProjectManager;
++import org.netbeans.api.project.ProjectUtils;
++import org.netbeans.api.project.SourceGroup;
  import org.netbeans.api.project.ui.ProjectProblems;
 +import org.netbeans.modules.java.platform.implspi.JavaPlatformProvider;
  import org.openide.filesystems.FileObject;
 -import org.openide.util.Exceptions;
++import org.openide.filesystems.FileUtil;
  import org.openide.util.Lookup;
  
  /**
-@@ -55,130 +61,205 @@ import org.openide.util.Lookup;
+@@ -55,130 +67,261 @@ import org.openide.util.Lookup;
   */
  public class LspServerTelemetryManager {
  
@@ -86,7 +91,7 @@ index d82646afb1..7f4c88acd1 100644
 +
 +        private static final LspServerTelemetryManager instance = new LspServerTelemetryManager();
 +    }
- 
++
 +    private final WeakHashMap<LanguageClient, WeakReference<Future<Void>>> clients = new WeakHashMap<>();
 +    private volatile boolean telemetryEnabled = false;
 +    private long lspServerIntializationTime;
@@ -94,7 +99,7 @@ index d82646afb1..7f4c88acd1 100644
 +    public boolean isTelemetryEnabled() {
 +        return telemetryEnabled;
 +    }
-+
+ 
 +    public void connect(LanguageClient client, Future<Void> future) {
          synchronized (clients) {
 -            for (Map.Entry<LanguageClient, Future<Void>> entry : clients.entrySet()) {
@@ -168,21 +173,21 @@ index d82646afb1..7f4c88acd1 100644
      }
  
 -    public void sendWorkspaceInfo(LanguageClient client, List<FileObject> workspaceClientFolders, Collection<Project> prjs, long timeToOpenPrjs) {
+-        JsonObject properties = new JsonObject();
+-        JsonArray prjProps = new JsonArray();
 +    private boolean isInvalidClient(WeakReference<Future<Void>> closeListener) {
 +        Future<Void> close = closeListener == null ? null : closeListener.get();
 +        return close == null || close.isDone();
 +    }
-+
-+    public CompletableFuture<Void> sendWorkspaceInfo(LanguageClient client, List<FileObject> workspaceClientFolders, Collection<Project> projects, long timeToOpenProjects) {
-         JsonObject properties = new JsonObject();
--        JsonArray prjProps = new JsonArray();
-+        List<CompletableFuture<JsonObject>> createProjectFutures = new ArrayList<>();
  
 -        Map<String, Project> mp = prjs.stream()
 -                .collect(Collectors.toMap(project -> project.getProjectDirectory().getPath(), project -> project));
++    public CompletableFuture<Void> sendWorkspaceInfo(LanguageClient client, List<FileObject> workspaceClientFolders, Collection<Project> projects, long timeToOpenProjects) {
++        JsonObject properties = new JsonObject();
+ 
 +        NavigableMap<String, Project> mp = projects.stream()
 +                .collect(Collectors.toMap(project -> project.getProjectDirectory().getPath(), project -> project, (p1, p2) -> p1, TreeMap<String, Project>::new));
- 
++        List<CompletableFuture<JsonObject>> createProjectFutures = new ArrayList<>();
          for (FileObject workspaceFolder : workspaceClientFolders) {
              try {
 -                JsonObject obj = new JsonObject();
@@ -190,13 +195,52 @@ index d82646afb1..7f4c88acd1 100644
                  String prjPath = workspaceFolder.getPath();
 -                String prjId = this.getPrjId(prjPath);
 -                obj.addProperty("id", prjId);
--                
++                String prjPathWithSlash = null;
++                for (Map.Entry<String, Project> p : mp.tailMap(prjPath, true).entrySet()) {
++                    String projectPath = p.getKey();
++                    if (prjPathWithSlash == null) {
++                        if (prjPath.equals(projectPath)) {
++                            createProjectFutures.add(createProjectInfo(prjPath, p.getValue(), workspaceFolder, client));
++                            noProjectFound = false;
++                            break;
++                        }
++                        prjPathWithSlash = prjPath + '/';
++                    }
++                    if (projectPath.startsWith(prjPathWithSlash)) {
++                        createProjectFutures.add(createProjectInfo(p.getKey(), p.getValue(), workspaceFolder, client));
++                        noProjectFound = false;
++                        continue;
++                    }
++                    break;
++                }
++                if (noProjectFound) {
++                    // No project found
++                    createProjectFutures.add(createProjectInfo(prjPath, null, workspaceFolder, client));
++                }
++            } catch (NoSuchAlgorithmException e) {
++                LOG.log(Level.INFO, "NoSuchAlgorithmException while creating workspaceInfo event: {0}", e.getMessage());
++            } catch (Exception e) {
++                LOG.log(Level.INFO, "Exception while creating workspaceInfo event: {0}", e.getMessage());
++            }
++        }
+                 
 -                // In future if different JDK is used for different project then this can be updated 
 -                obj.addProperty("javaVersion", System.getProperty("java.version"));
--
++        return CompletableFuture.allOf(createProjectFutures.toArray(new CompletableFuture[0]))
++                .thenApply((ignored) -> {
++                    JsonArray prjProps = new JsonArray();
++                    createProjectFutures.forEach((f) -> prjProps.add(f.join()));
++                    return prjProps;
++                })
++                .thenAccept((prjProps) -> {
++                    properties.add("projectInfo", prjProps);
+ 
 -                if (mp.containsKey(prjPath)) {
 -                    Project prj = mp.get(prjPath);
--
++                    properties.addProperty("projInitTimeTaken", timeToOpenProjects);
++                    properties.addProperty("numProjects", workspaceClientFolders.size());
++                    properties.addProperty("lspInitTimeTaken", System.currentTimeMillis() - this.lspServerIntializationTime);
+ 
 -                    ProjectManager.Result r = ProjectManager.getDefault().isProject2(prj.getProjectDirectory());
 -                    String projectType = r.getProjectType();
 -                    obj.addProperty("buildTool", (projectType.contains("maven") ? "MavenProject" : "GradleProject"));
@@ -212,59 +256,15 @@ index d82646afb1..7f4c88acd1 100644
 -
 -                    boolean isPreviewFlagEnabled = this.isEnablePreivew(workspaceFolder, this.STANDALONE_PRJ);
 -                    obj.addProperty("enablePreview", isPreviewFlagEnabled);
-+                String prjPathWithSlash = null;
-+                for (Map.Entry<String, Project> p : mp.tailMap(prjPath, true).entrySet()) {
-+                    String projectPath = p.getKey();
-+                    if (prjPathWithSlash == null) {
-+                        if (prjPath.equals(projectPath)) {
-+                            createProjectFutures.add(createProjectInfo(prjPath, p.getValue(), workspaceFolder, client));
-+                            noProjectFound = false;
-+                            break;
-+                        }
-+                        prjPathWithSlash = prjPath + '/';                        
-+                    }
-+                    if (projectPath.startsWith(prjPathWithSlash)) {
-+                        createProjectFutures.add(createProjectInfo(p.getKey(), p.getValue(), workspaceFolder, client));
-+                        noProjectFound = false;
-+                        continue;
-+                    }
-+                    break;
-                 }
+-                }
 -
 -                prjProps.add(obj);
--
--            } catch (NoSuchAlgorithmException ex) {
--                Exceptions.printStackTrace(ex);
-+                if (noProjectFound) {
-+                    // No project found
-+                    createProjectFutures.add(createProjectInfo(prjPath, null, workspaceFolder, client));
-+                }
-+            } catch (NoSuchAlgorithmException e) {
-+                LOG.log(Level.INFO, "NoSuchAlgorithmException while creating workspaceInfo event: {0}", e.getMessage());
-+            } catch (Exception e) {
-+                LOG.log(Level.INFO, "Exception while creating workspaceInfo event: {0}", e.getMessage());
-             }
-         }
- 
--        properties.add("prjsInfo", prjProps);
-+        return CompletableFuture.allOf(createProjectFutures.toArray(new CompletableFuture[0]))
-+                .thenApply((ignored) -> {
-+                    JsonArray prjProps = new JsonArray();
-+                    createProjectFutures.forEach((f) -> prjProps.add(f.join()));
-+                    return prjProps;
-+                })
-+                .thenAccept((prjProps) -> {
-+                    properties.add("projectInfo", prjProps);
-+                    properties.addProperty("projInitTimeTaken", timeToOpenProjects);
-+                    properties.addProperty("numProjects", workspaceClientFolders.size());
-+                    properties.addProperty("lspInitTimeTaken", System.currentTimeMillis() - this.lspServerIntializationTime);
 +                    this.sendTelemetry(client, new TelemetryEvent(MessageType.Info.toString(), LspServerTelemetryManager.WORKSPACE_INFO_EVT, properties));
 +                });
 +    }
  
--        properties.addProperty("timeToOpenPrjs", timeToOpenPrjs);
--        properties.addProperty("numOfPrjsOpened", workspaceClientFolders.size());
--        properties.addProperty("lspServerInitializationTime", System.currentTimeMillis() - this.lspServerIntiailizationTime);
+-            } catch (NoSuchAlgorithmException ex) {
+-                Exceptions.printStackTrace(ex);
 +    private CompletableFuture<JsonObject> createProjectInfo(String prjPath, Project prj, FileObject workspaceFolder, LanguageClient client) throws NoSuchAlgorithmException {
 +        JsonObject obj = new JsonObject();
 +        String prjId = getPrjId(prjPath);
@@ -283,28 +283,35 @@ index d82646afb1..7f4c88acd1 100644
 +            } catch (RuntimeException e) {
 +                LOG.log(Level.INFO, "Exception while checking project problems for workspaceInfo event: {0}", e.getMessage());
 +                projectHasProblems = true;
-+            }
+             }
 +            obj.addProperty("isOpenedWithProblems", projectHasProblems);
-+        }
+         }
 +        String javaVersion = getProjectJavaVersion();
 +        obj.addProperty("javaVersion", javaVersion);
-+        obj.addProperty("buildTool", projectType.name());
-+        return isPreviewEnabled(projectDirectory, projectType, client).thenApply(isPreviewFlagEnabled -> {
++        if (projectType != null) obj.addProperty("buildTool", projectType.name());
++        return isPreviewEnabled(projectDirectory, prj, client).thenApply(isPreviewFlagEnabled -> {
 +            obj.addProperty("isPreviewEnabled", isPreviewFlagEnabled);
 +            return obj;
 +        });
 +    }
  
+-        properties.add("prjsInfo", prjProps);
+-
+-        properties.addProperty("timeToOpenPrjs", timeToOpenPrjs);
+-        properties.addProperty("numOfPrjsOpened", workspaceClientFolders.size());
+-        properties.addProperty("lspServerInitializationTime", System.currentTimeMillis() - this.lspServerIntiailizationTime);
+-
 -        this.sendTelemetry(client, new TelemetryEvent(MessageType.Info.toString(), this.WORKSPACE_INFO_EVT, properties));
-+    public CompletableFuture<Boolean> isPreviewEnabled(FileObject source, ProjectType prjType) {
-+        return isPreviewEnabled(source, prjType, null);
++    public CompletableFuture<Boolean> isPreviewEnabled(FileObject source, Project prj) {
++        return isPreviewEnabled(source, prj, null);
      }
 -    
 -    private boolean isEnablePreivew(FileObject source, String prjType) {
 -        if (prjType.equals(this.STANDALONE_PRJ)) {
 -            NbCodeLanguageClient client = Lookup.getDefault().lookup(NbCodeLanguageClient.class);
 +
-+    public CompletableFuture<Boolean> isPreviewEnabled(FileObject source, ProjectType prjType, LanguageClient languageClient) {
++    public CompletableFuture<Boolean> isPreviewEnabled(FileObject source, Project prj, LanguageClient languageClient) {
++        ProjectType prjType = prj == null ? ProjectType.standalone : getProjectType(prj);
 +        if (prjType == ProjectType.standalone) {
 +            NbCodeLanguageClient client = languageClient instanceof NbCodeLanguageClient ? (NbCodeLanguageClient) languageClient : null;
              if (client == null) {
@@ -320,25 +327,76 @@ index d82646afb1..7f4c88acd1 100644
 -            client.configuration(new ConfigurationParams(Collections.singletonList(conf))).thenAccept(c -> {
 -                String config = ((JsonPrimitive) ((List<Object>) c).get(0)).getAsString();
 -                isEnablePreviewSet.set(config.contains(this.ENABLE_PREVIEW));
--            });
--            
--            return isEnablePreviewSet.get();
 +            conf.setSection(client.getNbCodeCapabilities().getConfigurationPrefix() + "runConfig.vmOptions");
 +            return client.configuration(new ConfigurationParams(Collections.singletonList(conf)))
 +                    .thenApply(c -> {
 +                        return c != null && !c.isEmpty()
 +                                && ((JsonPrimitive) c.get(0)).getAsString().contains(ENABLE_PREVIEW);
-+                    });
+             });
+             
+-            return isEnablePreviewSet.get();
          }
--        
+         
++        boolean previewEnabled;
++        previewEnabled = source != null && isPreviewEnabledForSource(source);
++        if (!previewEnabled && prjType == ProjectType.gradle) {
++            assert prj != null;
++            FileObject prjRoot = prj.getProjectDirectory();            
++            String relativePath = prjRoot == null ? null : FileUtil.getRelativePath(prjRoot, source);
++            if (relativePath == null || relativePath.isEmpty()) {
++                // The source is not inside the project root, and,
++                // so the project contents need to be checked for preview-enabled
++                previewEnabled = previewEnabled || isPreviewEnabledForAnyProjectSourceRoot(prj);
++                previewEnabled = previewEnabled || isPreviewEnabledForAnyContainedProjects(prj);
++            }
++        }
 +
++        return CompletableFuture.completedFuture(previewEnabled);
++    }
++
++    private boolean isPreviewEnabledForAnyContainedProjects(@NonNull Project project) {
++        Set<Project> subProjects = ProjectUtils.getContainedProjects(project, false);
++        if (subProjects != null) {
++            for (Project subProject : subProjects) {
++                if (isPreviewEnabledForAnyProjectSourceRoot(subProject)) {
++                    return true;
++                }
++            }
++            for (Project subProject : subProjects) {
++                if (isPreviewEnabledForAnyContainedProjects(subProject)) {
++                    return true;
++                }
++            }
++        }
++        return false;
++    }
++
++    private boolean isPreviewEnabledForAnyProjectSourceRoot(@NonNull Project project) {
++        SourceGroup[] sources = ProjectUtils.getSources(project).getSourceGroups(JavaProjectConstants.SOURCES_TYPE_JAVA);
++        if (sources == null || sources.length == 0) {
++            FileObject root = project.getProjectDirectory();
++            if (root != null && isPreviewEnabledForSource(root)) {
++                return true;
++            }
++        } else {
++            for (SourceGroup s : sources) {
++                FileObject root = s.getRootFolder();
++                if (root != null && isPreviewEnabledForSource(root)) {
++                    return true;
++                }
++            }
++        }
++        return false;
++    }
++
++    private boolean isPreviewEnabledForSource(@NonNull FileObject source) {
          Result result = CompilerOptionsQuery.getOptions(source);
 -        return result.getArguments().contains(this.ENABLE_PREVIEW);
-+        return CompletableFuture.completedFuture(result.getArguments().contains(ENABLE_PREVIEW));
++        return result.getArguments().contains(ENABLE_PREVIEW);
      }
  
      private String getPrjId(String prjPath) throws NoSuchAlgorithmException {
-@@ -187,15 +268,50 @@ public class LspServerTelemetryManager {
+@@ -187,15 +330,54 @@ public class LspServerTelemetryManager {
  
          BigInteger number = new BigInteger(1, hash);
  
@@ -387,9 +445,13 @@ index d82646afb1..7f4c88acd1 100644
 +    }
 +
 +    public ProjectType getProjectType(Project prj) {
-+        ProjectManager.Result r = ProjectManager.getDefault().isProject2(prj.getProjectDirectory());
++        FileObject prjDir = prj.getProjectDirectory();
++        ProjectManager.Result r = prjDir == null ? null : ProjectManager.getDefault().isProject2(prjDir);
 +        String projectType = r == null ? null : r.getProjectType();
-+        return projectType != null && projectType.contains(ProjectType.maven.name()) ? ProjectType.maven : ProjectType.gradle;
++        return projectType == null ? null
++                : projectType.contains(ProjectType.maven.name()) ? ProjectType.maven
++                : projectType.contains(ProjectType.gradle.name()) ? ProjectType.gradle
++                : null;
 +    }
  }
 diff --git a/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java b/java/java.lsp.server/src/org/netbeans/modules/java/lsp/server/protocol/NbCodeClientCapabilities.java


### PR DESCRIPTION
1. For gradle projects, the CompilerOptionsQuery provides the required compiler arguments for a Source file/folder, not the project root. Thus, fixed the public LspServerTelemetryManager.isPreviewEnabled() methods to query the source roots of the current gradle project and sub-projects in order to check for the existence of the enable-preview compiler argument.
2. Fixed LspServerTelemetryManger.getProjectType() to return "gradle" only when the project name contains "gradle". For other kinds of netbeans projects, not maven/gradle, the returned value is null. This avoids wrong metrics collected for unsupported project types, such as ant, openjdk, make etc.