### PR TITLE
Refactor notebook glob expansion to use filesystem-driven matching

### DIFF
--- a/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookConfigs.java
+++ b/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookConfigs.java
@@ -127,14 +127,20 @@ public class NotebookConfigs {
                 if (c != null) {
                     JsonArray classPathConfig = NotebookUtils.getArgument(c, 0, JsonArray.class);
                     if (classPathConfig != null) {
-                        classPath = String.join(File.pathSeparator,classPathConfig.asList().stream().map((elem) -> elem.getAsString()).toList());
+                        List<String> classPathEntries = classPathConfig.asList().stream()
+                                .map(elem -> elem.getAsString())
+                                .toList();
+                        classPath = String.join(File.pathSeparator, NotebookUtils.expandGlobPaths(classPathEntries));
                     } else {
                         classPath = null;
                     }
                     
                     JsonArray modulePathConfig = NotebookUtils.getArgument(c, 1, JsonArray.class);
                     if (modulePathConfig != null) {
-                        modulePath = String.join(File.pathSeparator,modulePathConfig.asList().stream().map((elem) -> elem.getAsString()).toList());
+                        List<String> modulePathEntries = modulePathConfig.asList().stream()
+                                .map(elem -> elem.getAsString())
+                                .toList();
+                        modulePath = String.join(File.pathSeparator, NotebookUtils.expandGlobPaths(modulePathEntries));
                     } else {
                         modulePath = null;
                     }

--- a/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookUtils.java
+++ b/nbcode/notebooks/src/org/netbeans/modules/nbcode/java/notebook/NotebookUtils.java
@@ -20,6 +20,13 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.nio.file.InvalidPathException;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
@@ -89,6 +96,74 @@ public class NotebookUtils {
 
     public static boolean checkEmptyString(String input) {
         return (input == null || input.trim().isEmpty());
+    }
+
+    public static List<String> expandGlobPaths(List<String> entries) {
+        if (entries == null || entries.isEmpty()) {
+            return entries;
+        }
+        List<String> expanded = new ArrayList<>();
+        for (String entry : entries) {
+            if (checkEmptyString(entry)) {
+                continue;
+            }
+            Path entryPath;
+            try {
+                entryPath = Paths.get(entry);
+            } catch (InvalidPathException ex) {
+                expanded.add(entry);
+                continue;
+            }
+            if (Files.exists(entryPath)) {
+                expanded.add(entry);
+                continue;
+            }
+            List<String> matches = expandGlobEntry(entry, entryPath);
+            if (matches.isEmpty()) {
+                expanded.add(entry);
+            } else {
+                expanded.addAll(matches);
+            }
+        }
+        return expanded;
+    }
+
+    private static List<String> expandGlobEntry(String pattern, Path entryPath) {
+        List<String> matches = new ArrayList<>();
+        Path root = findExistingRoot(entryPath);
+        if (root == null) {
+            return matches;
+        }
+        PathMatcher matcher = FileSystems.getDefault().getPathMatcher("glob:" + pattern);
+        boolean absolutePattern = entryPath.isAbsolute();
+        try {
+            Files.walk(root)
+                    .filter(path -> {
+                        Path matchPath = absolutePattern ? path : root.relativize(path);
+                        return matcher.matches(matchPath);
+                    })
+                    .forEach(path -> matches.add(path.toString()));
+        } catch (IOException ex) {
+            return matches;
+        }
+        return matches;
+    }
+
+    private static Path findExistingRoot(Path path) {
+        Path current = path;
+        while (current != null && !Files.exists(current)) {
+            current = current.getParent();
+        }
+        if (current == null) {
+            return null;
+        }
+        try {
+            return current.toRealPath();
+        } catch (InvalidPathException ex) {
+            return null;
+        } catch (IOException ex) {
+            return current.toAbsolutePath();
+        }
     }
 
     @SuppressWarnings("unchecked")

--- a/nbcode/notebooks/test/unit/src/org/netbeans/modules/nbcode/java/notebook/NotebookConfigsTest.java
+++ b/nbcode/notebooks/test/unit/src/org/netbeans/modules/nbcode/java/notebook/NotebookConfigsTest.java
@@ -21,10 +21,14 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonPrimitive;
 import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 import org.eclipse.lsp4j.ConfigurationItem;
 import org.eclipse.lsp4j.ConfigurationParams;
 import org.junit.After;
@@ -232,6 +236,40 @@ public class NotebookConfigsTest {
             
         } catch (Exception ex) {
             fail("Configuration with quoted spaces failed");
+        }
+    }
+
+    @Test
+    public void testGlobExpansionForNotebookPaths() {
+        try {
+            Path tempDir = Files.createTempDirectory("notebook-configs");
+            Path libsDir = Files.createDirectories(tempDir.resolve("lib"));
+            Path jarOne = Files.createFile(libsDir.resolve("one.jar"));
+            Path jarTwo = Files.createFile(libsDir.resolve("two.jar"));
+            Files.createFile(libsDir.resolve("readme.txt"));
+
+            JsonArray classpath = new JsonArray();
+            classpath.add(new JsonPrimitive(libsDir.resolve("*.jar").toString()));
+            updateConfigValue(CLASSPATH_KEY, classpath);
+
+            Path modulesDir = Files.createDirectories(tempDir.resolve("modules"));
+            Path moduleOne = Files.createDirectories(modulesDir.resolve("module.one"));
+            JsonArray modulepath = new JsonArray();
+            modulepath.add(new JsonPrimitive(modulesDir.resolve("*").toString()));
+            updateConfigValue(MODULEPATH_KEY, modulepath);
+
+            instance.getInitialized().get(5, TimeUnit.SECONDS);
+
+            List<String> classpathEntries = Arrays.asList(
+                    instance.getClassPath().split(Pattern.quote(File.pathSeparator)));
+            assertTrue(classpathEntries.contains(jarOne.toString()));
+            assertTrue(classpathEntries.contains(jarTwo.toString()));
+
+            List<String> modulepathEntries = Arrays.asList(
+                    instance.getModulePath().split(Pattern.quote(File.pathSeparator)));
+            assertTrue(modulepathEntries.contains(moduleOne.toString()));
+        } catch (Exception ex) {
+            fail("Configuration initialization failed");
         }
     }
     

--- a/nbcode/notebooks/test/unit/src/org/netbeans/modules/nbcode/java/notebook/NotebookUtilsTest.java
+++ b/nbcode/notebooks/test/unit/src/org/netbeans/modules/nbcode/java/notebook/NotebookUtilsTest.java
@@ -1,5 +1,8 @@
 package org.netbeans.modules.nbcode.java.notebook;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
 import org.eclipse.lsp4j.Position;
 import org.junit.Test;
 import static org.junit.Assert.*;
@@ -117,6 +120,25 @@ public class NotebookUtilsTest {
         assertEquals("abc\n def \nghi jkl\nm\n", NotebookUtils.applyChange(multiLine, new Position(3, 0), new Position(3, 0), "m\r\n"));
         assertEquals("abc\n xyz\ndef \nghi\njkl\n", NotebookUtils.applyChange(multiLine, new Position(1, 1), new Position(2, 4), "xyz\ndef \nghi\n"));
         assertEquals("abc\n def \nghi jkl\nmo", NotebookUtils.applyChange(multiLine + "mno", new Position(3, 1), new Position(3, 2), ""));
+    }
+
+    @Test
+    public void testExpandGlobPaths() throws Exception {
+        Path tempDir = Files.createTempDirectory("notebook-utils");
+        Path libsDir = Files.createDirectories(tempDir.resolve("lib"));
+        Path jarOne = Files.createFile(libsDir.resolve("one.jar"));
+        Path jarTwo = Files.createFile(libsDir.resolve("two.jar"));
+        Files.createFile(libsDir.resolve("readme.txt"));
+
+        String jarPattern = libsDir.resolve("*.jar").toString();
+        String missingPattern = tempDir.resolve("missing").resolve("*.jar").toString();
+
+        List<String> expanded = NotebookUtils.expandGlobPaths(List.of(jarPattern, "plain/path", missingPattern));
+
+        assertTrue(expanded.contains(jarOne.toString()));
+        assertTrue(expanded.contains(jarTwo.toString()));
+        assertTrue(expanded.contains("plain/path"));
+        assertTrue(expanded.contains(missingPattern));
     }
     
 }


### PR DESCRIPTION
### Motivation
- Fix brittle hardcoded glob-character detection and incorrect glob expansion so notebook `classpath`/`modulepath` relative patterns resolve consistently and expand to concrete file paths before launch. 
- Prefer using the real filesystem and `PathMatcher` rather than manual regex parsing and ad-hoc prefix handling for more robust glob support.

### Description
- Replaced character-based glob detection with parsing each entry into a `Path` and checking filesystem existence in `NotebookUtils.expandGlobPaths` so existing paths are preserved and non-existing entries are considered for expansion. 
- Added `expandGlobEntry(String pattern, Path entryPath)` which locates the nearest existing ancestor via `findExistingRoot` and uses `FileSystems.getDefault().getPathMatcher("glob:" + pattern)` to match candidates under that root. 
- Updated `NotebookConfigs` to call `NotebookUtils.expandGlobPaths` when building `classPath` and `modulePath` so configuration entries are expanded consistently. 
- Preserved original entry when parsing fails or when a glob yields no matches and handled invalid paths/missing roots gracefully.

### Testing
- Added unit tests `NotebookUtilsTest.testExpandGlobPaths` to exercise filesystem glob expansion and `NotebookConfigsTest.testGlobExpansionForNotebookPaths` to validate integration with configuration initialization. 
- No automated test suite was executed as part of this change (tests were added but not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698585341abc8330ae65e43303ae60a7)